### PR TITLE
V1.0.2: Avoiding Clashes with Context.sol

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ This contract can work instead of, or along side the OpenZeppelin Pausable.sol c
 
 This contract is in development and should only be used after performing independent testing.
 
-Install with: `npm i selective-pausable`
+Install with: `npm i @uintgroup/selective-pausable`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "selective-pausable",
+  "name": "@uintgroup/selective-pausable",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "selective-pausable",
+      "name": "@uintgroup/selective-pausable",
       "version": "1.0.0",
       "license": "ISC"
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uintgroup/selective-pausable",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "An expansion on OpenZeppelin's Pausable.sol. This contract adds the ability to pause each function by its selector.",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "selective-pausable",
+  "name": "@uintgroup/selective-pausable",
   "version": "1.0.0",
   "description": "An expansion on OpenZeppelin's Pausable.sol. This contract adds the ability to pause each function by its selector.",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   "bugs": {
     "url": "https://github.com/uintgroup/selective-pausable/issues"
   },
-  "homepage": "https://github.com/uintgroup/selective-pausable#readme"
+  "homepage": "https://github.com/uintgroup/selective-pausable#readme",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
 }

--- a/src/SelectivePausable.sol
+++ b/src/SelectivePausable.sol
@@ -37,11 +37,11 @@ abstract contract SelectivePausable {
      * @dev Reverts if the function of the function selector in _msgSig() is paused.
      */
     modifier whenNotPausedSelective(bool _pauseAfterCall) {
-        if (functionIsPaused[_msgSig()]) {
-            revert FunctionIsPaused(_msgSig());
+        if (functionIsPaused[_msgSigPausableSelective()]) {
+            revert FunctionIsPaused(_msgSigPausableSelective());
         }
         _;
-        functionIsPaused[_msgSig()] = _pauseAfterCall;
+        functionIsPaused[_msgSigPausableSelective()] = _pauseAfterCall;
     }
 
     /**
@@ -52,7 +52,11 @@ abstract contract SelectivePausable {
         bool _isPaused
     ) internal virtual {
         functionIsPaused[_functionSelector] = _isPaused;
-        emit FunctionIsPausedUpdate(_msgSender(), _functionSelector, _isPaused);
+        emit FunctionIsPausedUpdate(
+            _msgSenderPausableSelective(),
+            _functionSelector,
+            _isPaused
+        );
     }
 
     /**
@@ -69,7 +73,7 @@ abstract contract SelectivePausable {
         for (uint256 i = 0; i < _selectors.length; i++) {
             functionIsPaused[_selectors[i]] = _isPaused[i];
             emit FunctionIsPausedUpdate(
-                _msgSender(),
+                _msgSenderPausableSelective(),
                 _selectors[i],
                 _isPaused[i]
             );
@@ -79,14 +83,19 @@ abstract contract SelectivePausable {
     /**
      * @dev Replaces need to import OpenZeppelin's Context.sol. Returns the msg.sender.
      */
-    function _msgSender() internal view virtual returns (address) {
+    function _msgSenderPausableSelective()
+        internal
+        view
+        virtual
+        returns (address)
+    {
         return msg.sender;
     }
 
     /**
      * @dev Returns the msg.sig (function selector).
      */
-    function _msgSig() internal view virtual returns (bytes4) {
+    function _msgSigPausableSelective() internal view virtual returns (bytes4) {
         return msg.sig;
     }
 }

--- a/src/SelectivePausable.sol
+++ b/src/SelectivePausable.sol
@@ -47,7 +47,7 @@ abstract contract SelectivePausable {
     /**
      * @dev Modifies pause state of a single function.
      */
-    function _setIsPaused(
+    function _setFunctionIsPaused(
         bytes4 _functionSelector,
         bool _isPaused
     ) internal virtual {


### PR DESCRIPTION
Renamed what was `_msgSender()` to `_msgSenderPausableSelective()`. Perhaps this isn't necessary, but follows the pattern set by OZ's context.